### PR TITLE
fix index out of range

### DIFF
--- a/clipper/src/readsToWiggle.pyx
+++ b/clipper/src/readsToWiggle.pyx
@@ -134,6 +134,7 @@ def get_full_length_cigar(read):
             for x in xrange(times):
                 cur_position += 1
                 yield cur_position
+            continue
 
         for x in xrange(times):
             cur_position = next(positions)[1]


### PR DESCRIPTION
# Issue
Reads that have a lot of deletions are causing the read to extend past the annotation length, which causes an `index out of range` exception to occur in `readsToWiggle.pyx`.

# Line causing index error (113)
wiggle[cur_pos - tx_start] += increment_value

# Specific values causing error

`wiggle[39,567,510 - 39,567,373] += 1.0`

OR wiggle[137] += 1.0, which is > then the gene size of 137 bp

# Values when above line errors
```
Gene size: 137
usePos: start
keepstrand: -
increment_value: 1.0
next_pos: 39,567,508
read_start: 39,567,407
read_stop: 39,567,509
read_start_d: 39,567,509
read_stop_d: 39,567,406
record_read: True
tx_start: 39,567,373
tx_end: 39,567,509
cur_pos: 39,567,510
read_len: 89

positions: [39567407, 39567408, 39567409, 39567410, 39567411, 39567412, 39567413, 39567414, 39567415, 39567416, 39567417, 39567418, 39567419, 39567420, 39567421, 39567422, 39567423, 39567424, 39567436, 39567437, 39567438, 39567439, 39567440, 39567441, 39567442, 39567443, 39567444, 39567445, 39567446, 39567447, 39567448, 39567449, 39567450, 39567451, 39567452, 39567453, 39567454, 39567455, 39567456, 39567457, 39567458, 39567459, 39567460, 39567461, 39567462, 39567463, 39567464, 39567465, 39567466, 39567467, 39567468, 39567469, 39567470, 39567471, 39567472, 39567473, 39567474, 39567475, 39567476, 39567477, 39567478, 39567479, 39567480, 39567481, 39567482, 39567483, 39567484, 39567485, 39567486, 39567487, 39567488, 39567489, 39567490, 39567491, 39567492, 39567493, 39567497, 39567498, 39567499, 39567500, 39567501, 39567502, 39567503, 39567504, 39567505, 39567506, 39567507, 39567508, 39567509]

read.positions: [39567407, 39567408, 39567409, 39567410, 39567411, 39567412, 39567413, 39567414, 39567415, 39567416, 39567417, 39567418, 39567419, 39567420, 39567421, 39567422, 39567423, 39567424, 39567436, 39567437, 39567438, 39567439, 39567440, 39567441, 39567442, 39567443, 39567444, 39567445, 39567446, 39567447, 39567448, 39567449, 39567450, 39567451, 39567452, 39567453, 39567454, 39567455, 39567456, 39567457, 39567458, 39567459, 39567460, 39567461, 39567462, 39567463, 39567464, 39567465, 39567466, 39567467, 39567468, 39567469, 39567470, 39567471, 39567472, 39567473, 39567474, 39567475, 39567476, 39567477, 39567478, 39567479, 39567480, 39567481, 39567482, 39567483, 39567484, 39567485, 39567486, 39567487, 39567488, 39567489, 39567490, 39567491, 39567492, 39567493, 39567497, 39567498, 39567499, 39567500, 39567501, 39567502, 39567503, 39567504, 39567505, 39567506, 39567507, 39567508, 39567509]

read.cigartuples: [(4, 1), (0, 18), (2, 11), (0, 58), (2, 3), (0, 13)]

value: 4
times: 1
value: 0
times: 18
cur_position: 39567407
cur_position: 39567408
cur_position: 39567409
cur_position: 39567410
cur_position: 39567411
cur_position: 39567412
cur_position: 39567413
cur_position: 39567414
cur_position: 39567415
cur_position: 39567416
cur_position: 39567417
cur_position: 39567418
cur_position: 39567419
cur_position: 39567420
cur_position: 39567421
cur_position: 39567422
cur_position: 39567423
cur_position: 39567424
value: 2
times: 11
cur_position: 39567425
cur_position: 39567426
cur_position: 39567427
cur_position: 39567428
cur_position: 39567429
cur_position: 39567430
cur_position: 39567431
cur_position: 39567432
cur_position: 39567433
cur_position: 39567434
cur_position: 39567435
cur_position: 39567436
cur_position: 39567437
cur_position: 39567438
cur_position: 39567439
cur_position: 39567440
cur_position: 39567441
cur_position: 39567442
cur_position: 39567443
cur_position: 39567444
cur_position: 39567445
cur_position: 39567446
value: 0
times: 58
cur_position: 39567447
cur_position: 39567448
cur_position: 39567449
cur_position: 39567450
cur_position: 39567451
cur_position: 39567452
cur_position: 39567453
cur_position: 39567454
cur_position: 39567455
cur_position: 39567456
cur_position: 39567457
cur_position: 39567458
cur_position: 39567459
cur_position: 39567460
cur_position: 39567461
cur_position: 39567462
cur_position: 39567463
cur_position: 39567464
cur_position: 39567465
cur_position: 39567466
cur_position: 39567467
cur_position: 39567468
cur_position: 39567469
cur_position: 39567470
cur_position: 39567471
cur_position: 39567472
cur_position: 39567473
cur_position: 39567474
cur_position: 39567475
cur_position: 39567476
cur_position: 39567477
cur_position: 39567478
cur_position: 39567479
cur_position: 39567480
cur_position: 39567481
cur_position: 39567482
cur_position: 39567483
cur_position: 39567484
cur_position: 39567485
cur_position: 39567486
cur_position: 39567487
cur_position: 39567488
cur_position: 39567489
cur_position: 39567490
cur_position: 39567491
cur_position: 39567492
cur_position: 39567493
cur_position: 39567497
cur_position: 39567498
cur_position: 39567499
cur_position: 39567500
cur_position: 39567501
cur_position: 39567502
cur_position: 39567503
cur_position: 39567504
cur_position: 39567505
cur_position: 39567506
cur_position: 39567507
value: 2
times: 3
cur_position: 39567508
cur_position: 39567509
cur_position: 39567510
cur_position: 39567508
cur_position: 39567509

read: A00953:238:HTYL3DSXY:4:1167:3432:12759_GTGGCAGTGA  16      24      39567407        255     1S18M11D58M3D13M        -1      -1      89      GCAAATGGAAAACAACCTGTCTGCTCATTCTGTAGCACCATCTGTCCCCACACCGGCACGAGGCAGCAAGGAATGGGGATTCAGGTGCTC      array('B', [37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 25, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 25, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37, 37])    [('NH', 1), ('HI', 1), ('AS', 69), ('nM', 0), ('NM', 14), ('MD', '18^TCTGGATTTCC58^AAA13'), ('jM', array('b', [-1])), ('jI', array('i', [-1]))]
```

# BAM Line giving issues

`read: A00953:238:HTYL3DSXY:4:1167:3432:12759_GTGGCAGTGA 16 chr1 39567408 255 1S18M11D58M3D13M * 0 0 GCAAATGGAAAACAACCTGTCTGCTCATTCTGTAGCACCATCTGTCCCCACACCGGCACGAGGCAGCAAGGAATGGGGATTCAGGTGCTC FFFFFFFFFFFFFFFFFFF:FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF:FFFFFFFFFFFFFFFFFF NH:i:1 HI:i:1 AS:i:69 nM:i:0 NM:i:14 MD:Z:18^TCTGGATTTCC58^AAA13 jM:B:c,-1 jI:B:i,-1`


But if you notice...`cur_position` is looping twice at `val == 2`. Adding `continue` here fixes this:

# The fix
```
if value == 2:  #In the case of a deletion yeild from the previous current position, this could be buggy in the case of deletions occuring after anything but a match
            for x in xrange(times):
                cur_position += 1
                yield cur_position
             continue
```

We now get the following after adding the `continue` fix.

```
read.cigartuples: [(4, 1), (0, 18), (2, 11), (0, 58), (2, 3), (0, 13)]
value: 4
times: 1

continue

value: 0
times: 18

times iter: 0
cur_position: 39567407
times iter: 1
cur_position: 39567408
times iter: 2
cur_position: 39567409
times iter: 3
cur_position: 39567410
times iter: 4
cur_position: 39567411
times iter: 5
cur_position: 39567412
times iter: 6
cur_position: 39567413
times iter: 7
cur_position: 39567414
times iter: 8
cur_position: 39567415
times iter: 9
cur_position: 39567416
times iter: 10
cur_position: 39567417
times iter: 11
cur_position: 39567418
times iter: 12
cur_position: 39567419
times iter: 13
cur_position: 39567420
times iter: 14
cur_position: 39567421
times iter: 15
cur_position: 39567422
times iter: 16
cur_position: 39567423
times iter: 17
cur_position: 39567424

value: 2
times: 11

times iter (val=2): 0
cur_position (val=2): 39567425
times iter (val=2): 1
cur_position (val=2): 39567426
times iter (val=2): 2
cur_position (val=2): 39567427
times iter (val=2): 3
cur_position (val=2): 39567428
times iter (val=2): 4
cur_position (val=2): 39567429
times iter (val=2): 5
cur_position (val=2): 39567430
times iter (val=2): 6
cur_position (val=2): 39567431
times iter (val=2): 7
cur_position (val=2): 39567432
times iter (val=2): 8
cur_position (val=2): 39567433
times iter (val=2): 9
cur_position (val=2): 39567434
times iter (val=2): 10
cur_position (val=2): 39567435

value: 0
times: 58

times iter: 0
cur_position: 39567436
times iter: 1
cur_position: 39567437
times iter: 2
cur_position: 39567438
times iter: 3
cur_position: 39567439
times iter: 4
cur_position: 39567440
times iter: 5
cur_position: 39567441
times iter: 6
cur_position: 39567442
times iter: 7
cur_position: 39567443
times iter: 8
cur_position: 39567444
times iter: 9
cur_position: 39567445
times iter: 10
cur_position: 39567446
times iter: 11
cur_position: 39567447
times iter: 12
cur_position: 39567448
times iter: 13
cur_position: 39567449
times iter: 14
cur_position: 39567450
times iter: 15
cur_position: 39567451
times iter: 16
cur_position: 39567452
times iter: 17
cur_position: 39567453
times iter: 18
cur_position: 39567454
times iter: 19
cur_position: 39567455
times iter: 20
cur_position: 39567456
times iter: 21
cur_position: 39567457
times iter: 22
cur_position: 39567458
times iter: 23
cur_position: 39567459
times iter: 24
cur_position: 39567460
times iter: 25
cur_position: 39567461
times iter: 26
cur_position: 39567462
times iter: 27
cur_position: 39567463
times iter: 28
cur_position: 39567464
times iter: 29
cur_position: 39567465
times iter: 30
cur_position: 39567466
times iter: 31
cur_position: 39567467
times iter: 32
cur_position: 39567468
times iter: 33
cur_position: 39567469
times iter: 34
cur_position: 39567470
times iter: 35
cur_position: 39567471
times iter: 36
cur_position: 39567472
times iter: 37
cur_position: 39567473
times iter: 38
cur_position: 39567474
times iter: 39
cur_position: 39567475
times iter: 40
cur_position: 39567476
times iter: 41
cur_position: 39567477
times iter: 42
cur_position: 39567478
times iter: 43
cur_position: 39567479
times iter: 44
cur_position: 39567480
times iter: 45
cur_position: 39567481
times iter: 46
cur_position: 39567482
times iter: 47
cur_position: 39567483
times iter: 48
cur_position: 39567484
times iter: 49
cur_position: 39567485
times iter: 50
cur_position: 39567486
times iter: 51
cur_position: 39567487
times iter: 52
cur_position: 39567488
times iter: 53
cur_position: 39567489
times iter: 54
cur_position: 39567490
times iter: 55
cur_position: 39567491
times iter: 56
cur_position: 39567492
times iter: 57
cur_position: 39567493

value: 2
times: 3

times iter (val=2): 0
cur_position (val=2): 39567494
times iter (val=2): 1
cur_position (val=2): 39567495
times iter (val=2): 2
cur_position (val=2): 39567496

value: 0
times: 13

times iter: 0
cur_position: 39567497
times iter: 1
cur_position: 39567498
times iter: 2
cur_position: 39567499
times iter: 3
cur_position: 39567500
times iter: 4
cur_position: 39567501
times iter: 5
cur_position: 39567502
times iter: 6
cur_position: 39567503
times iter: 7
cur_position: 39567504
times iter: 8
cur_position: 39567505
times iter: 9
cur_position: 39567506
times iter: 10
cur_position: 39567507
times iter: 11
cur_position: 39567508
times iter: 12
cur_position: 39567509
```

# Why this happens?
We end up with `index error` because we're counting coverage outside of the gene.

There are `If statements` for each type of cigar entry. For matches, it's looping through and yielding for each match. If it's a soft clip, insert, or anything not aligned, it continues by not yielding any position. For deletions, it's yielding positions deleted but after the `if statement` there is no `continue`, so it goes into the loop below.

In other words, if the deletion is ten bases, it goes through ten times but doesn't exit the `for loop`. It keeps going and delivers 10 more times with the code below that is specifically for matches. So, all deletions are double counted and double extend the read. Adding a `continue` stops this behavior.